### PR TITLE
feat: use dev env as default API for im-web-client

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -119,8 +119,20 @@ jobs:
       - name: Set hostnames based on environment
         run: |
           echo "API_HOSTNAME=api.im.$ENVIRONMENT.test.c.dhis2.org" >> $GITHUB_ENV
-          echo "API_URL=https://api.im.$ENVIRONMENT.test.c.dhis2.org" >> $GITHUB_ENV
           echo "UI_HOSTNAME=im.$ENVIRONMENT.test.c.dhis2.org" >> $GITHUB_ENV
+
+      - name: Set API_URL for im-web-client
+        if: github.repository == 'dhis2-sre/im-web-client'
+        run: |
+          # default to dev environment
+          echo "API_URL=https://api.im.dev.test.c.dhis2.org" >> $GITHUB_ENV
+
+          # use matching environment branch if it exists
+          MATCHING_API_URL=https://api.im.$ENVIRONMENT.test.c.dhis2.org
+          HEALTH_STATUS=$(curl -sSL $MATCHING_API_URL/health | jq -r '.status')
+          if [[ "$HEALTH_STATUS" == "UP" ]]; then
+            echo "API_URL=$MATCHING_API_URL" >> $GITHUB_ENV
+          fi
 
       - name: Environment
         run: env


### PR DESCRIPTION
Small improvement for the web-client deployments - check if an API environment with matching name exists and use it or default to using the dev one.

Test workflow runs:
* [without a matching API environment available](https://github.com/dhis2-sre/im-web-client/actions/runs/5724386363/job/15518715852#step:13:25) (defaulting to dev)
* [with a matching API environment available](https://github.com/dhis2-sre/im-web-client/actions/runs/5724386363/job/15518939644#step:13:25)