### PR TITLE
ci: install helm/helmfile/sops before running integration tests

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -66,6 +66,25 @@ jobs:
       - name: Run pre-commit checks
         run: make check
 
+      - name: Install helm/helmfile/sops
+        uses: alexellis/arkade-get@master
+        with:
+          helm: v3.12.3
+          helmfile: v0.156.0
+          sops: v3.7.3
+
+      # im-manager expects helmfile/helm to be in /usr/bin
+      - name: Move CLIs to /usr/bin
+        run: |
+          sudo mv $HOME/.arkade/bin/* /usr/bin/
+
+      - name: Setup helm secrets plugin
+        if: ${{ env.DEPLOY_ENVIRONMENT == 'true' }}
+        run: helm plugin install https://github.com/jkroepke/helm-secrets --version v3.8.3
+
+      - name: Run unit and integration tests
+        run: make test
+
       - name: Create dotenv from example
         run: |
           cp .env.example .env
@@ -210,11 +229,6 @@ jobs:
 #      - name: End smoke test
 #        run: make clean
 
-      - name: Run unit and integration tests
-        run: make test
-        env:
-          IMAGE_TAG: ${{ env.VERSION }}
-
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -287,14 +301,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: Setup Sops
-        if: ${{ env.DEPLOY_ENVIRONMENT == 'true' }}
-        uses: mdgreenwald/mozilla-sops-action@v1.4.1
-
-      - name: Setup helm secrets plugin
-        if: ${{ env.DEPLOY_ENVIRONMENT == 'true' }}
-        run: helm plugin install https://github.com/jkroepke/helm-secrets --version v3.8.3
 
       - name: Lint Helm
         if: ${{ env.DEPLOY_ENVIRONMENT == 'true' }}

--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -82,9 +82,6 @@ jobs:
         if: ${{ env.DEPLOY_ENVIRONMENT == 'true' }}
         run: helm plugin install https://github.com/jkroepke/helm-secrets --version v3.8.3
 
-      - name: Run unit and integration tests
-        run: make test
-
       - name: Create dotenv from example
         run: |
           cp .env.example .env
@@ -228,6 +225,11 @@ jobs:
 
 #      - name: End smoke test
 #        run: make clean
+
+      - name: Run unit and integration tests
+        run: make test
+        env:
+          IMAGE_TAG: ${{ env.VERSION }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2


### PR DESCRIPTION
as they are needed by the im-manager integration tests. Use arkade to install the needed tools.

We cannot run the integration tests before building the Docker image as im-inspector runs tests against the Docker image.