### PR TITLE
ci: use actions-cool/maintain-one-comment to comment [DEVOPS-277]

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -350,30 +350,14 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Add deployed environment URL as comment
-        uses: actions/github-script@v6
+      - name: Comment deployed environment URL
+        uses: actions-cool/maintain-one-comment@v3
         if: ${{ env.DEPLOY_ENVIRONMENT == 'true' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v') }}
+        env:
+          # TODO update once https://github.com/actions/runner/issues/409 is resolved
+          APP_URL: "https://${{ contains(github.repository, 'im-web-client') && env.UI_HOSTNAME || env.API_HOSTNAME }}"
         with:
-          script: |
-            let app_url
-
-            switch (context.repo.repo) {
-              case 'im-manager':
-                app_url = `https://${{ env.API_HOSTNAME }}`
-                break
-              case 'im-web-client':
-                app_url = `https://${{ env.UI_HOSTNAME }}`
-                break
-              default:
-                return
-            }
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `App deployed to ${app_url}`
-            })
+          body: "App deployed to ${{ env.APP_URL }}"
 
   send-slack-message:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a bit of a hacky solution, based on [this example workaround](https://docs.github.com/en/actions/learn-github-actions/expressions#example) for a ternary operator. See https://github.com/actions/runner/issues/409 for more details.

It does work quite neatly for this case, though. Will need to be revised once the whole workflow is refactored or when we have another app to deploy with a different URL (hopefully not).

See test runs of this step for both [im-manager](https://github.com/dhis2-sre/im-manager/actions/runs/6849231298/job/18624768583#step:42:1) and [im-web-client](https://github.com/dhis2-sre/im-web-client/actions/runs/6850034788/job/18624772568?pr=299#step:42:1) repos.