### PR TITLE
chore: lets not print the env

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -156,9 +156,6 @@ jobs:
             echo "API_URL=$MATCHING_API_URL" >> $GITHUB_ENV
           fi
 
-      - name: Environment
-        run: env
-
       - name: Create RSA keypair
         run: |
           if make keys; then


### PR DESCRIPTION
as Github is not 100% accurate in obfuscating secrets