### PR TITLE
chore: use retry with timeout on healthcheck

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -204,9 +204,9 @@ jobs:
       - name: Confirm ${{ inputs.HEALTH_CHECK_ENDPOINT }} returns 200
         if: ${{ env.hasPort }}
         run: |
-          docker ps
+          docker ps --all
           docker compose logs prod
-          curl --silent --fail localhost:8080${{ inputs.HEALTH_CHECK_ENDPOINT }}
+          timeout 1m bash -c 'until curl --silent --fail localhost:8080${{ inputs.HEALTH_CHECK_ENDPOINT }}; do sleep 2; done'
 
       - name: Confirm process isn't running as root
         run: |

--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -190,18 +190,18 @@ jobs:
           GIN_MODE: debug
 
       - name: Confirm ${{ inputs.HEALTH_CHECK_ENDPOINT }} returns 200
+        id: healthcheck
         run: |
-          (timeout 1m bash -c 'until curl --silent --fail localhost:8080${{ inputs.HEALTH_CHECK_ENDPOINT }}; do sleep 2; done')
-          exit_code=$?
-          if [ $exit_code -ne 0 ]; then
-            echo "Healthcheck failed with exit code $exit_code"
+          timeout 1m bash -c 'until curl --silent --fail localhost:8080${{ inputs.HEALTH_CHECK_ENDPOINT }}; do sleep 2; done'
+
+      - name: Debug failed healthcheck
+        if: always() && (steps.healthcheck.outcome == 'failure')
+        run: |
             docker ps --all
+            echo "docker compose logs prod"
             docker compose logs prod
-            exit $exit_code
-          else
-            echo "Healthcheck succeeded"
-            exit 0
-          fi
+            echo "Healthcheck after smoke test failed"
+            exit 1
 
       - name: Confirm process isn't running as root
         run: |

--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -191,9 +191,17 @@ jobs:
 
       - name: Confirm ${{ inputs.HEALTH_CHECK_ENDPOINT }} returns 200
         run: |
-          docker ps --all
-          docker compose logs prod
-          timeout 1m bash -c 'until curl --silent --fail localhost:8080${{ inputs.HEALTH_CHECK_ENDPOINT }}; do sleep 2; done'
+          (timeout 1m bash -c 'until curl --silent --fail localhost:8080${{ inputs.HEALTH_CHECK_ENDPOINT }}; do sleep 2; done')
+          exit_code=$?
+          if [ $exit_code -ne 0 ]; then
+            echo "Healthcheck failed with exit code $exit_code"
+            docker ps --all
+            docker compose logs prod
+            exit $exit_code
+          else
+            echo "Healthcheck succeeded"
+            exit 0
+          fi
 
       - name: Confirm process isn't running as root
         run: |

--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -186,23 +186,10 @@ jobs:
       - name: Smoke test image
         run: |
           make smoke-test tag=$VERSION
-
-          hasPort=$(docker inspect $(docker compose ps -q prod) | jq -r '.[0].HostConfig.PortBindings."8080/tcp" | .[0].HostPort' | tr -d null)
-          if [ -n "$hasPort" ]; then
-            echo "hasPort: $hasPort"
-            echo "hasPort=$hasPort" >> $GITHUB_ENV
-          else
-            echo "No port found!"
-          fi
-
-          sleep 5
-          docker ps
-          docker compose logs prod
         env:
           GIN_MODE: debug
 
       - name: Confirm ${{ inputs.HEALTH_CHECK_ENDPOINT }} returns 200
-        if: ${{ env.hasPort }}
         run: |
           docker ps --all
           docker compose logs prod

--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -212,8 +212,8 @@ jobs:
         env:
           IMAGE_TAG: ${{ env.VERSION }}
 
-#      - name: End smoke test
-#        run: make clean
+      - name: End smoke test
+        run: make clean
 
       - name: Run unit and integration tests
         run: make test


### PR DESCRIPTION
So we do not have to put a sleep in our smoke-test to wait for an unknown time for our app to be ready.

Until now, the IM smoke-test starts the DB and RabbitMQ in the background, sleeps for a bit and then starts IM. We obviously do not know if the services are truly ready after that sleep. With a retry and timeout we can run all we need using a single `docker compose up` and let our Docker healthcheck and dependencies take care of order and waiting.

Print the status of `--all` containers as we otherwise do not see the state/status of an exited one.

Example of a failed run https://github.com/dhis2-sre/im-manager/actions/runs/9542300209/job/26296890310?pr=792

```
Run docker ps --all
CONTAINER ID   IMAGE                          COMMAND                  CREATED              STATUS                        PORTS                                                                                                                                                 NAMES
44208fe8031c   dhis2/im-manager:misc          "/app/im-manager"        About a minute ago   Exited (1) 59 seconds ago                                                                                                                                                           im-manager-prod-1
98d1daf2bed5   rabbitmq:3-management-alpine   "docker-entrypoint.s…"   About a minute ago   Up About a minute (healthy)   4369/tcp, 5671/tcp, 0.0.0.0:5672->5672/tcp, :::5672->5672/tcp, 15671/tcp, 15691-15692/tcp, 25672/tcp, 0.0.0.0:15672->15672/tcp, :::15672->15672/tcp   im-manager-rabbitmq-1
fcf63c906599   postgres:13-alpine             "docker-entrypoint.s…"   About a minute ago   Up About a minute (healthy)   0.0.0.0:5432->5432/tcp, :::5432->5432/tcp                                                                                                             im-manager-database-1
0efdbb6db49b   redis:6.2.5-alpine3.14         "docker-entrypoint.s…"   About a minute ago   Up About a minute (healthy)   0.0.0.0:6379->6379/tcp, :::6379->6379/tcp                                                                                                             im-manager-redis-1
docker compose logs prod
prod-1  | {"time":"2024-06-17T05:17:22.3[77](https://github.com/dhis2-sre/im-manager/actions/runs/9542300209/job/26296890310?pr=792#step:21:78)828022Z","level":"ERROR","msg":"should gha not show the logs?"}
Healthcheck after smoke test failed
Error: Process completed with exit code 1.
```