### PR TITLE
chore: trim last dash of sanitized branch name

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -122,6 +122,9 @@ jobs:
           # the rest of the chars up to the limit are saved for the static part of the release names
           SANITIZED_HEAD_BRANCH=${HEAD_BRANCH_LOWERCASE_NO_NONALPHANUMERIC::25}
 
+          # trim last "-" if there is one
+          SANITIZED_HEAD_BRANCH=$(echo $SANITIZED_HEAD_BRANCH | sed 's/\-$//')
+
           echo "ENVIRONMENT=$SANITIZED_HEAD_BRANCH" >> $GITHUB_ENV
           echo "CLASSIFICATION=feature" >> $GITHUB_ENV
           echo "SANITIZED_HEAD_BRANCH=$SANITIZED_HEAD_BRANCH" >> $GITHUB_ENV


### PR DESCRIPTION
A trailing dash results in the below deployment error

```
Tags used in deployment:
 - dhis2/im-web-client -> dhis2/im-web-client:devops-304-status-colors-
Starting deploy...
Helm release im-web-client-devops-304-status-colors- not installed. Installing...
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/runner/work/im-web-client/im-web-client/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/runner/work/im-web-client/im-web-client/.kube/config
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/runner/work/im-web-client/im-web-client/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/runner/work/im-web-client/im-web-client/.kube/config
Error: INSTALLATION FAILED: release name "im-web-client-devops-304-status-colors-": invalid release name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 53
deploying "im-web-client-devops-304-status-colors-": install: exit status 1
```