### PR TITLE
chore: check prod exit code if no health endpoint exists

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -194,6 +194,7 @@ jobs:
 
       - name: Confirm ${{ inputs.HEALTH_CHECK_ENDPOINT }} returns 200
         id: healthcheck
+        if: "${{ inputs.HEALTH_CHECK_ENDPOINT != '' }}"
         run: |
           timeout 1m bash -c 'until curl --silent --fail localhost:8080${{ inputs.HEALTH_CHECK_ENDPOINT }}; do sleep 2; done'
 
@@ -205,6 +206,11 @@ jobs:
             docker compose logs prod
             echo "Healthcheck after smoke test failed"
             exit 1
+
+      - name: Confirm process exited with code 0
+        if: "${{ inputs.HEALTH_CHECK_ENDPOINT == '' }}"
+        run: |
+          exit_code=$(docker inspect $(docker compose ps --quiet prod) | jq -r '.[0].State.ExitCode'); echo "Service 'prod' exited with code $exit_code"; [ "$exit_code" -eq 0 ]
 
       - name: Confirm process isn't running as root
         run: |


### PR DESCRIPTION
This will be run for im-inspector which is a CronJob. It is important we check that the job ran successfully.