### PR TITLE
ci: use ubuntu-22.04 runner

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -48,7 +48,7 @@ jobs:
   build:
     env:
       DEPLOY_ENVIRONMENT: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy')) }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
[im-manager integration tests started failing](https://github.com/dhis2-sre/im-manager/actions/runs/10281208080/job/28464150262#step:26:261) at some point and upon investigation the following line has been seen in the k8s logs:
```
2024-08-08T12:50:34.9426284Z "message": "0/1 nodes are available: 1 node(s) had untolerated taint {node.kubernetes.io/disk-pressure: }. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.."
```

Using `ubuntu-22.04` runner seems to resolve this 🤷 