### PR TITLE
chore: bump ubuntu

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -48,7 +48,7 @@ jobs:
   build:
     env:
       DEPLOY_ENVIRONMENT: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy')) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/im-delete-env.yaml
+++ b/.github/workflows/im-delete-env.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   delete-env:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I noticed the below warning when running [this](https://github.com/dhis2-sre/im-web-client/actions/runs/14791184364) workflow and thought it was time for an upgrade.

    This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

I tested the upgrade [here](https://github.com/dhis2-sre/im-web-client/pull/678) but I didn't bother testing it on the IM backend since we'll see immediately if it fails. And if it fails we need to update the workflow so it works with the latest version of Ubuntu rather than rolling back.