### PR TITLE
chore: remove pinning of kubectl

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -288,13 +288,6 @@ jobs:
         if: ${{ env.DEPLOY_ENVIRONMENT == 'true' }}
         run: aws-iam-authenticator version
 
-      - name: Pin kubectl to version v1.23.6 (https://github.com/aws/aws-cli/issues/6920)
-        if: ${{ env.DEPLOY_ENVIRONMENT == 'true' }}
-        run: |
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl
-          chmod +x ./kubectl
-          sudo mv ./kubectl /usr/local/bin/kubectl
-
       - name: Configure kubectl
         if: ${{ env.DEPLOY_ENVIRONMENT == 'true' }}
         run: |

--- a/.github/workflows/im-delete-env.yaml
+++ b/.github/workflows/im-delete-env.yaml
@@ -41,12 +41,6 @@ jobs:
       - name: Check aws-iam-authenticator version
         run: aws-iam-authenticator version
 
-      - name: Pin kubectl to version v1.23.6 (https://github.com/aws/aws-cli/issues/6920)
-        run: |
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl
-          chmod +x ./kubectl
-          sudo mv ./kubectl /usr/local/bin/kubectl
-
       - name: Configure kubectl
         run: |
           mkdir $PWD/.kube


### PR DESCRIPTION
For ages we're been pinning kubectl to an older version due to a bug in aws cli which should be long gone. I tested that it now works [here](https://github.com/dhis2-sre/im-web-client/pull/679) and this should be good to merge.