### PR TITLE
chore: bump go version to 1.26.2

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-go@v6.2.0
         with:
-          go-version: 1.25.5
+          go-version: 1.26.2
 
       - name: Install prerequisites
         run: make init


### PR DESCRIPTION
Bumps Go from 1.25.5 to 1.26.2.