### PR TITLE
ci: only remove Android SDK in free-disk-space step

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-go@v6.2.0
         with:
-          go-version: 1.25.5
+          go-version: 1.26.2
 
       - name: Install prerequisites
         run: make init

--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -85,6 +85,13 @@ jobs:
       # This fixes the K8s warning "Unschedulable, Message: 0/1 nodes are available: 1 node(s) had untolerated taint {node.kubernetes.io/disk-pressure: }. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling."
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main
+        with:
+          android: true
+          dotnet: false
+          haskell: false
+          large-packages: false
+          docker-images: false
+          swap-storage: false
 
       - name: Create dotenv from example
         run: |


### PR DESCRIPTION
Only remove the Android SDK instead of all available disk space categories, reducing the time spent in the free-disk-space step.