### PR TITLE
ci: replace blocked actions-cool/maintain-one-comment with sticky-pull-request-comment

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -362,12 +362,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Comment deployed environment URL
-        uses: actions-cool/maintain-one-comment@v3
+        uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ env.DEPLOY_ENVIRONMENT == 'true' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v') }}
         env:
           APP_URL: ${{ contains(github.repository, 'im-web-client') && env.UI_URL || format('https://{0}', env.API_HOSTNAME) }}
         with:
-          body: "App deployed to ${{ env.APP_URL }}"
+          header: deployed-env-url
+          message: "App deployed to ${{ env.APP_URL }}"
 
       - name: GitHub Release
         if: ${{ env.ENVIRONMENT == 'prod' }}


### PR DESCRIPTION
actions-cool/maintain-one-comment was blocked by GitHub for a TOS violation at 2026-05-19T00:34:15Z, which causes `Repository access blocked` at `Set up job` in every workflow that resolves this reusable workflow. Swap to marocchino/sticky-pull-request-comment@v2 which has the same single-comment-per-PR behavior via the header key.