### PR TITLE
fix: derive image name from docker-compose.yml

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -185,6 +185,21 @@ jobs:
 
           echo "VERSION=$VERSION"
 
+      - name: Setup yq
+        run: |
+          wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O /tmp/yq
+          sudo mv /tmp/yq /usr/bin/yq
+          chmod +x /usr/bin/yq
+        env:
+          VERSION: v4.2.0
+          BINARY: yq_linux_amd64
+
+      - name: Find image
+        run: |
+          IMAGE=$(yq e '.services.prod.image' docker-compose.yml | cut -f1 -d":")
+          echo "IMAGE=$IMAGE" >> $GITHUB_ENV
+          echo "IMAGE=$IMAGE"
+
 # TODO: Split here... "Build"
       - uses: docker/setup-buildx-action@v3
 
@@ -193,7 +208,7 @@ jobs:
         with:
           push: false
           load: true
-          tags: dhis2/im-manager:${{ env.VERSION }}
+          tags: ${{ env.IMAGE }}:${{ env.VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -258,20 +273,10 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: dhis2/im-manager:${{ env.VERSION }}
+          tags: ${{ env.IMAGE }}:${{ env.VERSION }}
           cache-from: type=gha
 
 # TODO: Split here... "Deploy"
-      - name: Setup yq
-        if: ${{ env.DEPLOY_ENVIRONMENT == 'true' }}
-        run: |
-          wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O /tmp/yq
-          sudo mv /tmp/yq /usr/bin/yq
-          chmod +x /usr/bin/yq
-        env:
-          VERSION: v4.2.0
-          BINARY: yq_linux_amd64
-
       - name: Update chart image tag
         if: ${{ env.DEPLOY_ENVIRONMENT == 'true' }}
         run: |
@@ -342,7 +347,6 @@ jobs:
       - name: Deploy
         if: ${{ env.DEPLOY_ENVIRONMENT == 'true' }}
         run: |
-          IMAGE=$(yq e '.services.prod.image' docker-compose.yml | cut -f1 -d":")
           SKAFFOLD_PROFILE=$([ "$CLASSIFICATION" == "feature" ] && echo "dev" || echo "$CLASSIFICATION")
 
           ./skaffold deploy --images $IMAGE:$VERSION --profile $SKAFFOLD_PROFILE


### PR DESCRIPTION
## Summary

PR #103 replaced the Makefile-based build/push steps with `docker/build-push-action@v6` and hardcoded `tags: dhis2/im-manager:\${{ env.VERSION }}`. That's correct for im-manager but breaks every other caller of this shared workflow. im-web-client master deploys, for example, push to `dhis2/im-manager:latest` while the chart still pulls `dhis2/im-web-client:latest`, so pods quietly restart onto a stale image and the GitHub Actions run still reports success.

This PR restores per-caller image names by deriving `IMAGE` from `docker-compose.yml` (the same way the deploy step already does) and using it in the build, push and deploy steps. `Setup yq` is hoisted out of the deploy block and made unconditional so it's available before the build step.

## Test plan

- [ ] Merge and confirm im-web-client master deploy pushes to `dhis2/im-web-client:latest` (Docker Hub `last_updated` advances)
- [ ] Confirm `https://im-dev.dhis2.org/` serves a JS bundle containing the Google SSO button after the next master push
- [ ] Confirm im-manager master deploys still work unchanged