### PR TITLE
feat: use ref_type == tag instead of startsWith refs/tags/v

### DIFF
--- a/.github/workflows/im-build-test-deploy.yaml
+++ b/.github/workflows/im-build-test-deploy.yaml
@@ -116,7 +116,7 @@ jobs:
           echo "CLASSIFICATION=dev" >> $GITHUB_ENV
 
       - name: "Environment: prod"
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: github.ref_type == 'tag'
         run: |
           echo "ENVIRONMENT=prod" >> $GITHUB_ENV
           echo "CLASSIFICATION=prod" >> $GITHUB_ENV
@@ -286,7 +286,7 @@ jobs:
       #          [ "$(git diff --exit-code $TARGET)" != "0" ]
 
       - name: Update chart version
-        if:  ${{ startsWith(github.ref, 'refs/tags/v') && env.DEPLOY_ENVIRONMENT == 'true' }}
+        if: ${{ github.ref_type == 'tag' && env.DEPLOY_ENVIRONMENT == 'true' }}
         run: |
           TARGET=helm/chart/Chart.yaml
           yq -i e ".version = \"${{ env.VERSION }}\"" $TARGET
@@ -367,7 +367,7 @@ jobs:
 
       - name: Comment deployed environment URL
         uses: marocchino/sticky-pull-request-comment@v3
-        if: ${{ env.DEPLOY_ENVIRONMENT == 'true' && github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ env.DEPLOY_ENVIRONMENT == 'true' && github.ref != 'refs/heads/master' && github.ref_type != 'tag' }}
         env:
           APP_URL: ${{ contains(github.repository, 'im-web-client') && env.UI_URL || format('https://{0}', env.API_HOSTNAME) }}
         with:


### PR DESCRIPTION
## Summary

- Replace all `startsWith(github.ref, 'refs/tags/v')` checks with `github.ref_type == 'tag'` (prod gate, chart version, PR comment guard)
- This is the gha-workflows side of a fix to eliminate duplicate tags per release: consuming repos currently push `vX.Y.Z` which the pipeline then strips to `X.Y.Z` and mints a second bare tag via `gh release create`. Switching the gate to `ref_type == 'tag'` is backward-compatible — it still fires on `v*` tags, so other repos keep working unchanged until they also switch to bare tags.
- The `VERSION#v` strip on the "Find version" step becomes a harmless no-op once consuming repos switch to bare tags.

## Test plan

- [ ] Verify prod deployment still triggers on a tag push after consuming repos switch to bare tags
- [ ] Verify chart version update step fires on tag push
- [ ] Verify PR environment URL comment still posts on feature branch PRs and not on tag pushes